### PR TITLE
更正錯別字和 main() 宣告更正

### DIFF
--- a/C語言概念澄清.md
+++ b/C語言概念澄清.md
@@ -76,7 +76,7 @@ void main(){
 
 ```c
 // 不接受額外的參數
-int main(){
+int main(void){
 
     return 0;
 }

--- a/C語言概念澄清.md
+++ b/C語言概念澄清.md
@@ -348,7 +348,7 @@ if(f){
 ## 8. 請務必熟悉字串的相關操作
 [字串操作大補帖](https://github.com/liao2000/Data-Structure-in-C/tree/master/String)
 
-## 9. 請務避理解記憶體的分配
+## 9. 請務必理解記憶體的分配
 
 <img src="https://blog.gtwang.org/wp-content/uploads/2017/03/memory-layout-of-c-program-diagram-20170301-1024x962.png" style="max-width:450px; width:100%;">
 


### PR DESCRIPTION
根據 C99 標準之 5.1.2.2.1 Program startup ， main() 的宣告只能為 `int main(void) { /* ... */ }` 或是 `int main(int argc, char *argv[]) { /* ... */ }` 。

參照連結：http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf